### PR TITLE
Add homepage and integrate Staircase tool with shared navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
 # QS-Tools
-Quantity Surveying Related Tools 
+
+Static site hosting quantity surveying tools.
+
+## Structure
+
+- `index.html` – main homepage with navigation.
+- `Staircase/` – Staircase formwork and volume calculator.

--- a/Staircase/index.html
+++ b/Staircase/index.html
@@ -2,23 +2,30 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF--8">
+    <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Staircase Formwork & Volume Calculator</title>
     <script src="https://cdn.tailwindcss.com"></script>
-<script type="importmap">
-{
-  "imports": {
-    "react-dom/": "https://esm.sh/react-dom@^19.1.0/",
-    "react/": "https://esm.sh/react@^19.1.0/",
-    "react": "https://esm.sh/react@^19.1.0"
-  }
-}
-</script>
-<link rel="stylesheet" href="/index.css">
+    <script type="importmap">
+    {
+      "imports": {
+        "react-dom/": "https://esm.sh/react-dom@^19.1.0/",
+        "react/": "https://esm.sh/react@^19.1.0/",
+        "react": "https://esm.sh/react@^19.1.0"
+      }
+    }
+    </script>
+    <link rel="stylesheet" href="index.css">
 </head>
-<body class="bg-gray-100">
-    <div id="root"></div>
-<script type="module" src="/index.tsx"></script>
+<body class="bg-gray-100 flex flex-col min-h-screen">
+    <nav class="bg-white shadow p-4 flex justify-between">
+        <div class="text-xl font-bold"><a href="../index.html">QS Tools</a></div>
+        <ul class="flex space-x-4">
+            <li><a href="../index.html" class="text-blue-500">Home</a></li>
+            <li><a href="./index.html" class="text-blue-500">Staircase</a></li>
+        </ul>
+    </nav>
+    <div id="root" class="flex-grow"></div>
+    <script type="module" src="index.tsx"></script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>QS Tools</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-gray-100 flex flex-col min-h-screen">
+  <nav class="bg-white shadow p-4 flex justify-between">
+    <div class="text-xl font-bold"><a href="./">QS Tools</a></div>
+    <ul class="flex space-x-4">
+      <li><a href="./index.html" class="text-blue-500">Home</a></li>
+      <li><a href="./Staircase/index.html" class="text-blue-500">Staircase</a></li>
+    </ul>
+  </nav>
+  <main class="flex-grow p-8">
+    <h1 class="text-3xl font-bold mb-4">Welcome to QS Tools</h1>
+    <p class="text-gray-700">Select a tool from the navigation to begin.</p>
+  </main>
+  <footer class="bg-white shadow p-4 text-center">
+    <p class="text-sm text-gray-500">&copy; 2025 QS Tools</p>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add Tailwind-styled homepage with navigation to the Staircase calculator.
- Update Staircase page to use shared navigation and relative asset paths.
- Document site structure in README.

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68b0130a349483269ab7ccc506bee7d0